### PR TITLE
read updated delete license

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,3 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 - Website - [https://nestjs.com](https://nestjs.com/)
 - Twitter - [@nestframework](https://twitter.com/nestframework)
 
-## License
-
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change removes the "License" section, which previously stated that Nest is MIT licensed, along with a link to the license file.